### PR TITLE
ARCH-1615 - Update syntax for setting outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ jobs:
       # Run the tests
       - name: Run tSqlt tests
         id: run-tests
-        uses: im-open/tsqlt-test-runner@v1.0.1
+        uses: im-open/tsqlt-test-runner@v1.1.0
         with:
           db-server-name: 'localhost'
           db-server-port: '1433'

--- a/action.yml
+++ b/action.yml
@@ -66,4 +66,4 @@ runs:
     - name: Output test results file path
       id: results-file
       shell: bash
-      run: echo "::set-output name=file_path::${{ github.action_path }}/test-results/test-results.xml"
+      run: echo "file_path=${{ github.action_path }}/test-results/test-results.xml" >> $GITHUB_OUTPUT

--- a/src/print-results.ps1
+++ b/src/print-results.ps1
@@ -25,6 +25,6 @@ Write-Output "Number of tests: $totalTests"
 Write-Output "Number of failures: $numFailed"
 Write-Output "Number of errors: $numErrored"
 
-echo "number_of_tests=$totalTests" >> $GITHUB_OUTPUT
-echo "number_of_failures=$numFailed" >> $GITHUB_OUTPUT
-echo "number_of_errors=$numErrored" >> $GITHUB_OUTPUT
+"number_of_tests=$totalTests" >> $env:GITHUB_OUTPUT
+"number_of_failures=$numFailed" >> $env:GITHUB_OUTPUT
+"number_of_errors=$numErrored" >> $env:GITHUB_OUTPUT

--- a/src/print-results.ps1
+++ b/src/print-results.ps1
@@ -25,6 +25,6 @@ Write-Output "Number of tests: $totalTests"
 Write-Output "Number of failures: $numFailed"
 Write-Output "Number of errors: $numErrored"
 
-echo "::set-output name=number_of_tests::$totalTests"
-echo "::set-output name=number_of_failures::$numFailed"
-echo "::set-output name=number_of_errors::$numErrored"
+echo "number_of_tests=$totalTests" >> $GITHUB_OUTPUT
+echo "number_of_failures=$numFailed" >> $GITHUB_OUTPUT
+echo "number_of_errors=$numErrored" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Summary of PR changes

-  Update syntax for setting outputs to comply with the [GitHub's new recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) to avoid logging untrusted data.
- The outputs that are set in the powershell script have slightly different syntax than the regular bash syntax.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
